### PR TITLE
Fix cookbook to run on rhel machines and fix source install when /etc/diamond does not already exist

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,7 +11,7 @@ default['diamond']['add_collectors'] = %w(cpu diskspace diskusage loadavg memory
 case node['platform_family']
 when 'debian'
   default['diamond']['version'] = '3.0.2'
-when 'redhat'
+when 'rhel'
   default['diamond']['version'] = '3.0.2-0'
 else
   default['diamond']['install_method'] = 'source'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email 'cbarraford@gmail.com'
 license          'All rights reserved'
 description      'Installs/Configures diamond'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0'
+version          '2.0.1'
 name             'diamond'
 
 supports         'ubuntu'

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -12,7 +12,7 @@ when 'debian'
     notifies :restart, 'service[diamond]'
   end
 
-when 'redhat'
+when 'rhel'
   include_recipe 'yum::default'
 
   package 'diamond' do

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -11,7 +11,7 @@ when 'debian'
   package 'python-configobj'
   package 'python-mock'
   package 'cdbs'
-when 'redhat'
+when 'rhel'
   include_recipe 'yum::default'
 
   package 'python-configobj'
@@ -23,7 +23,7 @@ git node['diamond']['source_path'] do
   repository node['diamond']['source_repository']
   reference node['diamond']['source_reference']
   action :sync
-  notifies :run, 'execute[build diamond]'
+  notifies :run, 'execute[build diamond]', :immediately
 end
 
 case node['platform_family']
@@ -31,7 +31,7 @@ when 'debian'
   execute 'build diamond' do
     command "cd #{node['diamond']['source_path']};make builddeb"
     action :nothing
-    notifies :run, 'execute[install diamond]'
+    notifies :run, 'execute[install diamond]', :immediately
   end
 
   execute 'install diamond' do
@@ -45,7 +45,7 @@ else
   execute 'build diamond' do
     command "cd #{node['diamond']['source_path']};make buildrpm"
     action :nothing
-    notifies :run, 'execute[install diamond]'
+    notifies :run, 'execute[install diamond]', :immediately
   end
 
   execute 'install diamond' do


### PR DESCRIPTION
Tested on rhel 6.5.
