### PR TITLE
Add support for Chef::DelayedEvaluator (lazy)

### DIFF
--- a/templates/default/collector_config.conf.erb
+++ b/templates/default/collector_config.conf.erb
@@ -1,6 +1,6 @@
 ### Options for <%= @params[:name] %>
 <% @params.each_pair do |k,v| -%> 
 <% if k.to_s != "name" and k.to_s != "snmp" and k.to_s != "action" %>
-<%= k.to_s.gsub('__','') %> = <%= v %>
+<%= k.to_s.gsub('__','') %> = <%= v.respond_to?(:call) ? v.call : v %>
 <% end %>
 <% end -%>

--- a/templates/default/snmp_collector_config.conf.erb
+++ b/templates/default/snmp_collector_config.conf.erb
@@ -2,7 +2,7 @@
 
 <% @params.each_pair do |k,v| -%> 
 <% if k.to_s != "name" and k.to_s != "devices" and k.to_s != "snmp" and k.to_s != "action" %>
-<%= k.to_s.gsub('__','') %> = <%= v %>
+<%= k.to_s.gsub('__','') %> = <%= v.respond_to?(:call) ? v.call : v %>
 <% end %>
 <% end -%> 
 


### PR DESCRIPTION
Add support for `Chef::DelayedEvaluator` (`lazy`) in collector definitions.
