### PR TITLE
Added ability to change ports, changed file permissions

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,8 @@
 default['diamond']['install_method'] = 'source'
 default['diamond']['graphite_server_role'] = nil
 default['diamond']['graphite_server'] = 'graphite'
+default['diamond']['graphite_port'] = '2003'
+default['diamond']['graphite_pickle_port'] = '2004'
 default['diamond']['path_prefix'] = 'servers'
 default['diamond']['hostname_method'] = 'smart'
 default['diamond']['interval'] = '300'

--- a/definitions/collector_conf.rb
+++ b/definitions/collector_conf.rb
@@ -1,7 +1,11 @@
 # definition to add/remove diamond collector configs
-define :collector_config, action: :create, enabled: 'True', snmp: false do
+define :collector_config, action: :create, enabled: 'True', snmp: false,
+  owner: 'root', group: 'root' do
+
   if params[:action] == :create
     Chef::Log.info("Create diamond collector config: #{params[:name]}.conf")
+    owner = params.delete(:owner)
+    group = params.delete(:group)
     template "/etc/diamond/collectors/#{params[:name]}.conf" do
       if params[:snmp] == false
         source 'collector_config.conf.erb'
@@ -9,9 +13,9 @@ define :collector_config, action: :create, enabled: 'True', snmp: false do
         source 'snmp_collector_config.conf.erb'
       end
       cookbook 'diamond'
-      owner 'root'
-      group 'root'
-      mode '0664'
+      owner owner
+      group group
+      mode '0660'
       variables(params: params)
       notifies :restart, 'service[diamond]'
     end

--- a/definitions/collector_conf.rb
+++ b/definitions/collector_conf.rb
@@ -11,7 +11,7 @@ define :collector_config, action: :create, enabled: 'True', snmp: false do
       cookbook 'diamond'
       owner 'root'
       group 'root'
-      mode '0660'
+      mode '0664'
       variables(params: params)
       notifies :restart, 'service[diamond]'
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email 'cbarraford@gmail.com'
 license          'All rights reserved'
 description      'Installs/Configures diamond'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.3'
+version          '2.0.4'
 name             'diamond'
 
 supports         'ubuntu'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email 'cbarraford@gmail.com'
 license          'All rights reserved'
 description      'Installs/Configures diamond'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.2'
+version          '2.0.3'
 name             'diamond'
 
 supports         'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,7 +29,9 @@ template '/etc/diamond/diamond.conf' do
   mode '0644'
   notifies :restart, 'service[diamond]'
   variables(
-    graphite_ip: graphite_ip
+    graphite_ip: graphite_ip,
+    graphite_port: node['diamond']['graphite_port'],
+    graphite_pickle_port: node['diamond']['graphite_pickle_port']
   )
 end
 

--- a/templates/default/diamond.conf.erb
+++ b/templates/default/diamond.conf.erb
@@ -59,7 +59,7 @@ days = 7
 host = <%= @graphite_ip %>
 
 # Port to send metrics to
-port = 2003
+port = <%= @graphite_port %>
 
 # Socket timeout (seconds)
 timeout = 15
@@ -74,7 +74,7 @@ batch = 1
 host = <%= @graphite_ip %>
 
 # Port to send metrics to
-port = 2004
+port = <%= @graphite_pickle_port %>
 
 # Socket timeout (seconds)
 timeout = 15


### PR DESCRIPTION
Diamond isn't always run as root, and the simplest change is to make conf files readable by everyone. In addition, we don't use default ports for our endpoints, so it's now configurable.