### PR TITLE
Add stove support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,18 @@
 source 'https://rubygems.org'
-ruby '2.0.0'
+ruby '2.3.1'
 #ruby-gemset=diamond-cookbook
 
 gem 'rake'
-gem 'berkshelf', '~> 3.1.3'
+gem 'berkshelf'
 
 group :development do
-  gem 'foodcritic', '~> 4.0'
-  gem 'rubocop', '~> 0.24.0'
+  gem 'stove'
+  gem 'foodcritic'
+  gem 'rubocop'
 end
 
 group :integration do
   gem 'serverspec'
-  gem 'test-kitchen', '~> 1.0'
+  gem 'test-kitchen'
   gem 'kitchen-vagrant'
 end

--- a/README.md
+++ b/README.md
@@ -69,3 +69,15 @@ USAGE
 It is recommended that you create a recipe per collector, and add that recipe to the related role.
 When passing sensitive data to a diamond collector config (ie a username, password, etc), use data bags 
 to encrypt the values.
+
+Publishing to [Chef Supermarket](https://supermarket.getchef.com/)
+=====
+
+To update the cookbook on the supermarket use
+[stove](https://supermarket.chef.io/tools/stove)
+
+**Example**
+```bash
+stove login --username sethvargo --key ~/.chef/cbarraford.pem
+stove
+```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ To update the cookbook on the supermarket use
 
 **Example**
 ```bash
-stove login --username sethvargo --key ~/.chef/cbarraford.pem
+stove login --username cbarraford --key ~/.chef/cbarraford.pem
 stove
 ```


### PR DESCRIPTION
Adds the ability to update the chef supermarket with new releases of the cookbook.

Special thanks to @drenalin23 for the tip about the tool.